### PR TITLE
Add task configuration to the queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.pyc
 *.egg-info
 dist
+build

--- a/blaster/__init__.py
+++ b/blaster/__init__.py
@@ -1,4 +1,4 @@
 from .core import BlasterError
 from .worker import Blaster
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'


### PR DESCRIPTION
Initially when a task was being processed, the queue (object to handle
data passed between parent and child processes) did not store any
attributes for a given task that may have been updated. This commit
brings the enhancement to add all task configuration to the queue.
Once all tasks are processed, it will then map the queue task data to
the initial task configurations. Which will return back the task
configuration with updated attributes (class objects, dicts, etc). That
may have been updated during task method call.