### PR TITLE
Limit the number of processes per blaster blastoff

### DIFF
--- a/blaster/__init__.py
+++ b/blaster/__init__.py
@@ -5,4 +5,4 @@ The blaster package.
 from .blast import Blaster
 from .core import BlasterError
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'

--- a/blaster/blast.py
+++ b/blaster/blast.py
@@ -2,10 +2,7 @@
 
 The blast module contains the main blaster class to run.
 """
-from copy import deepcopy
 from multiprocessing import Queue
-from pprint import pformat
-from time import sleep
 from uuid import uuid4
 
 from .core import BlasterError
@@ -13,7 +10,7 @@ from .core import CalcTimeMixin, LoggerMixin, ResultsList, TaskDefinition
 from .engine.processor import Processor
 
 
-class Blaster(LoggerMixin, CalcTimeMixin):
+class Blaster(CalcTimeMixin, LoggerMixin):
     """Blaster's main class."""
 
     def __init__(self, tasks, log_level='info'):
@@ -25,9 +22,17 @@ class Blaster(LoggerMixin, CalcTimeMixin):
         :type log_level: str
         """
         self.tasks = tasks
+
+        # create queues
+        self.task_queue = Queue()
+        self.done_queue = Queue()
+
+        # set list attributes
+        self.updated_tasks = list()
         self.processes = list()
         self.results = ResultsList()
-        self.queue = Queue()
+
+        # create blaster logger
         self.create_blaster_logger(log_level.lower())
 
     def blastoff(self, raise_on_failure=False):
@@ -46,8 +51,8 @@ class Blaster(LoggerMixin, CalcTimeMixin):
         # save start time
         self.start()
 
-        # build the list of processes to run
-        self.logger.debug('Start: building processes..')
+        # build updated task list
+        self.logger.debug('Reviewing tasks to ensure proper keys are defined.')
         for index, task in enumerate(self.tasks):
             index += 1
             task = TaskDefinition(task)
@@ -62,51 +67,63 @@ class Blaster(LoggerMixin, CalcTimeMixin):
             self.logger.info('%s. TASK ~ %s, METHODS: %s' %
                              (index, task['task'].__name__, task['methods']))
 
-            self.processes.append(Processor(deepcopy(task), self.queue))
-        self.logger.debug('End: building processes.')
-        self.logger.debug(pformat(self.processes))
+            # add updated task to list
+            self.updated_tasks.append(task)
+
         self.logger.info('.' * 30)
         self.logger.info('END: BLASTER PREPARATION')
         self.logger.info('.' * 30)
+
+        # submit tasks to queue
+        for task in self.updated_tasks:
+            self.task_queue.put(task)
 
         self.logger.info('.' * 30)
         self.logger.info('START: BLASTER BLAST OFF')
         self.logger.info('.' * 30)
 
+        # determine number of processes to start based on total tasks
+        if len(self.updated_tasks) >= 10:
+            NUMBER_OF_PROCESSES = 10
+        else:
+            NUMBER_OF_PROCESSES = len(self.updated_tasks)
+
+        self.logger.info(
+            'Total processes used by blaster is %s.' % NUMBER_OF_PROCESSES
+        )
+
+        # create worker processes
+        for i in range(NUMBER_OF_PROCESSES):
+            self.processes.append(Processor(self.task_queue, self.done_queue))
+
+        # start worker processes
+        for p in self.processes:
+            p.start()
+
         try:
-            # start processes
-            self.logger.info('Starting processes..')
-            for p in self.processes:
-                p.start()
-                self.logger.debug('Process %s started.' % p.name)
-                sleep(0.5)
+            # get status
+            for i in range(len(self.updated_tasks)):
+                self.results.append(self.done_queue.get())
 
-            # wait for all processes to finish
-            for p in self.processes:
-                sleep(0.5)
-                p.join()
-
-            # collect results
-            for p in self.processes:
-                self.results.append(self.queue.get())
+            # stop worker processes
+            for i in range(NUMBER_OF_PROCESSES):
+                self.task_queue.put('STOP')
 
             # correlate the results with initial tasks
-            for task in self.tasks:
+            for task in self.updated_tasks:
                 data = self.results.coordinate(task)
                 task.pop('_id')
                 data.pop('_id')
                 for key, value in data.items():
                     if key in task:
                         task[key] = value
-
-            self.logger.info('Blast off was able to run all tasks given!')
         except KeyboardInterrupt:
-            # collect results
-            for p in self.processes:
-                self.results.append(self.queue.get())
+            # get status
+            for i in range(len(self.updated_tasks)):
+                self.results.append(self.done_queue.get())
 
             # correlate the results with initial tasks
-            for task in self.tasks:
+            for task in self.updated_tasks:
                 data = self.results.coordinate(task)
                 task.pop('_id')
                 data.pop('_id')
@@ -118,16 +135,12 @@ class Blaster(LoggerMixin, CalcTimeMixin):
             for p in self.processes:
                 p.terminate()
                 p.join()
-                sleep(0.5)
 
             self.logger.info('Blast off was unable to run all tasks given '
                              'due to CRTL+C interrupt.')
         finally:
             # save end time
             self.end()
-
-            # update tasks list
-            # self.tasks = self.results
 
             # calculate time delta
             hour, minutes, seconds = self.delta()

--- a/blaster/engine/processor.py
+++ b/blaster/engine/processor.py
@@ -10,85 +10,84 @@ from traceback import print_exc
 class Processor(Process):
     """Processor class to handle calling all methods for a given task."""
 
-    def __init__(self, task_def, queue):
+    def __init__(self, in_queue, out_queue):
         """Constructor.
 
-        :param task_def: The task definition.
-        :type task_def: dict
-        :param queue: The queue to store process results.
-        :type queue: object
+        :param in_queue: Input queue.
+        :type in_queue: object
+        :param out_queue: Output queue.
+        :type out_queue: object
         """
         super(Processor, self).__init__()
-        self.task_def = task_def
-        self.queue = queue
-
-        self.task_obj = object
-        self.task_id = self.task_def['_id']
-        self.task_name = self.task_def['name']
-        self.task_cls = self.task_def.pop('task')
-        self.methods = self.task_def.pop('methods')
+        self.input = in_queue
+        self.output = out_queue
 
     def run(self):
         """Run the task methods."""
+        for task_def in iter(self.input.get, 'STOP'):
+            task_id = task_def['_id']
+            task_name = task_def['name']
+            task_cls = task_def['task']
+            methods = task_def['methods']
 
-        # results template
-        _res_struct = dict(
-            _id=self.task_id,
-            name=self.task_name,
-            task=self.task_cls,
-            status=None,
-            methods=list()
-        )
-
-        try:
-            # initialize task object
-            self.task_obj = self.task_cls(**self.task_def)
-
-            # run through tasks methods sequentially
-            for method in self.methods:
-                # call method
-                getattr(self.task_obj, method)()
-
-                # put method call results into queue
-                _res_struct['methods'].append(dict(
-                    name=method,
-                    status=0
-                ))
-
-            # put overall status
-            _res_struct.update(dict(status=0))
-        except Exception as ex:
-            # log traceback
-            print_exc()
+            # results template
+            _res_struct = dict(
+                _id=task_id,
+                name=task_name,
+                task=task_cls,
+                status=None,
+                methods=list()
+            )
 
             try:
+                # initialize object
+                task_obj = task_cls(**task_def)
+
+                # run through task methods sequentially
+                for method in methods:
+                    # call method
+                    getattr(task_obj, method)()
+
+                    # put method call results into queue
+                    _res_struct['methods'].append(dict(
+                        name=method,
+                        status=0
+                    ))
+
+                # put overall status
+                _res_struct.update(dict(status=0))
+            except Exception as ex:
+                # log traceback
+                print_exc()
+
+                try:
+                    # put method call results into queue
+                    _res_struct['methods'].append(dict(
+                        name=method,
+                        status=1,
+                        traceback=ex
+                    ))
+                except UnboundLocalError:
+                    _res_struct.update(dict(status=1, traceback=ex))
+
+                # put overall status
+                _res_struct.update(dict(status=1))
+            except KeyboardInterrupt as ex:
+                # log traceback
+                print_exc()
+
                 # put method call results into queue
                 _res_struct['methods'].append(dict(
                     name=method,
                     status=1,
                     traceback=ex
                 ))
-            except UnboundLocalError:
-                _res_struct.update(dict(status=1, traceback=ex))
 
-            # put overall status
-            _res_struct.update(dict(status=1))
-        except KeyboardInterrupt as ex:
-            # log traceback
-            print_exc()
+                # put overall status
+                _res_struct.update(dict(status=1))
+            finally:
+                # update task definition into queue
+                _res_struct.update(task_def)
 
-            # put method call results into queue
-            _res_struct['methods'].append(dict(
-                name=method,
-                status=1,
-                traceback=ex
-            ))
-
-            # put overall status
-            _res_struct.update(dict(status=1))
-        finally:
-            # update task definition into queue
-            _res_struct.update(self.task_def)
-
-            # put results into queue
-            self.queue.put(_res_struct)
+                # put results into queue
+                self.output.put(_res_struct)


### PR DESCRIPTION
This commit limits blaster to a certain amount of processes it can
spawn per blaster object. If the tasks passed to blaster exceeds more
than 10, it will only use 10 processes. Once a task is finished another
task will be handled by the process that just became free. If your
tasks is less than 10, it will spawn processes based on the number of
tasks to be blasted off.

Resolves #7 