### PR TITLE
Fixes bug not allowing traceback to be saved to results

### DIFF
--- a/blaster/engine/processor.py
+++ b/blaster/engine/processor.py
@@ -4,7 +4,8 @@ The processor module contains the main class which handles running tasks
 using the built-in Python multiprocessing library.
 """
 from multiprocessing import Process
-from traceback import print_exc
+from sys import exc_info
+from traceback import format_tb, print_exc
 
 
 class Processor(Process):
@@ -27,15 +28,14 @@ class Processor(Process):
         for task_def in iter(self.input.get, 'STOP'):
             task_id = task_def['_id']
             task_name = task_def['name']
-            task_cls = task_def['task']
-            methods = task_def['methods']
+            task_cls = task_def.pop('task')
+            methods = task_def.pop('methods')
 
             # results template
-            _res_struct = dict(
+            results = dict(
                 _id=task_id,
                 name=task_name,
                 task=task_cls,
-                status=None,
                 methods=list()
             )
 
@@ -49,45 +49,58 @@ class Processor(Process):
                     getattr(task_obj, method)()
 
                     # put method call results into queue
-                    _res_struct['methods'].append(dict(
+                    results['methods'].append(dict(
                         name=method,
                         status=0
                     ))
 
                 # put overall status
-                _res_struct.update(dict(status=0))
-            except Exception as ex:
-                # log traceback
-                print_exc()
+                results.update(dict(status=0))
+            except Exception:
+                # get traceback information
+                exc_data = self.get_traceback()
 
                 try:
                     # put method call results into queue
-                    _res_struct['methods'].append(dict(
+                    results['methods'].append(dict(
                         name=method,
                         status=1,
-                        traceback=ex
+                        traceback=format_tb(exc_data[2])
                     ))
                 except UnboundLocalError:
-                    _res_struct.update(dict(status=1, traceback=ex))
+                    results.update(dict(
+                        status=1,
+                        traceback=format_tb(exc_data[2])
+                    ))
 
                 # put overall status
-                _res_struct.update(dict(status=1))
-            except KeyboardInterrupt as ex:
-                # log traceback
-                print_exc()
+                results.update(dict(status=1))
+            except KeyboardInterrupt:
+                # get traceback information
+                exc_data = self.get_traceback()
 
                 # put method call results into queue
-                _res_struct['methods'].append(dict(
+                results['methods'].append(dict(
                     name=method,
                     status=1,
-                    traceback=ex
+                    traceback=format_tb(exc_data[2])
                 ))
 
                 # put overall status
-                _res_struct.update(dict(status=1))
+                results.update(dict(status=1))
             finally:
                 # update task definition into queue
-                _res_struct.update(task_def)
+                results.update(task_def)
 
                 # put results into queue
-                self.output.put(_res_struct)
+                self.output.put(results)
+
+    @staticmethod
+    def get_traceback():
+        """Get traceback when exception is raised. Will log traceback as well.
+
+        :return: Exception information.
+        :rtype: tuple
+        """
+        print_exc()
+        return exc_info()


### PR DESCRIPTION
The problem was at the end before adding results to the queue. It will
update the results with the initial task definition. This was overriding
the methods key. The methods key needed to be popped when creating the
results dictionary.

Closes #10 