### PR TITLE
Enable Python 3.6 test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: python
-python:
-  - "2.7"
-  - "3.6"
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+python:
+  - "2.7"
+  - "3.6"
 branches:
   only:
     - master

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,31 @@
-.PHONY: clean-pyc clean clean-tests tests tox
+.PHONY: clean tests tests-py27 tests-py36
 
-all: clean-pyc clean clean-tests
-
-clean-all: clean-pyc clean clean-tests
-
-tests: clean-tests tox
+all: clean tests
 
 clean:
 	rm -rf *.egg*
 	rm -rf .cache
-
-clean-pyc:
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f {} +
-
-clean-tests:
 	rm -rf .coverage
 	rm -rf .tox
 	rm -rf tests/coverage
 
-tox:
+tests:
+	rm -rf .coverage
+	rm -rf .tox
+	rm -rf tests/coverage
 	tox
+
+tests-py27:
+	rm -rf .coverage
+	rm -rf .tox
+	rm -rf tests/coverage
+	tox -e py27
+
+tests-py36:
+	rm -rf .coverage
+	rm -rf .tox
+	rm -rf tests/coverage
+	tox -e py36

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ tests:
 	rm -rf .coverage
 	rm -rf .tox
 	rm -rf tests/coverage
-	tox
+	tox -e py27
 
 tests-py27:
 	rm -rf .coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py{27}
-# envlist = py{27,36}
+envlist = py{27,36}
 [testenv]
 deps = -rtest-requirements.txt
 commands = nosetests -v --with-ignore-docstrings --with-coverage \


### PR DESCRIPTION
This commit also brings an updated makefile to test both Python2.7 and
Python3.6 or individually.